### PR TITLE
Disable unnecessary services + minor cleanups

### DIFF
--- a/pages/Firmware-Flash/_meta.json
+++ b/pages/Firmware-Flash/_meta.json
@@ -1,7 +1,6 @@
 {
-  "flash-m8p-v1-ebb": "Flash M8P V1 and Ebb sb2209",
-  "flash-m8p-v2-ebb": "Flash M8P V2 and Ebb sb2209",
-  "Updating_EBB_klipper_firmware_via_CanBoot": "Updating EBB klipper firmware via CanBoot",
-  "Updating_Manta_klipper_firmware_remotely": "Updating Manta klipper firmware remotely"
-
+  "flash-m8p-v2-ebb": "Flash M8P V2 and EBB SB2209",
+  "flash-m8p-v1-ebb": "Flash M8P V1 and EBB SB2209",
+  "Updating_EBB_klipper_firmware_via_CanBoot": "Updating EBB Klipper firmware via CanBoot",
+  "Updating_Manta_klipper_firmware_remotely": "Updating Manta Klipper firmware remotely"
 }

--- a/pages/Firmware-Flash/flash-m8p-v1-ebb.mdx
+++ b/pages/Firmware-Flash/flash-m8p-v1-ebb.mdx
@@ -1,10 +1,9 @@
+# CBT Kit Manta M8P V1 + CB1 Start Guide
+import { Callout } from 'nextra/components'
 
-
-# CBT Kit M8P+CB1 Start Guide
-
-
-
-
+<Callout type="warning">
+MPX kits stopped shipping with the V1 version of the Manta M8P in late 2023. Proceed with the instructions on this page only if you are absolutely sure that you have the V1 version of the Manta. The process for flashing the currently shipping Manta V2 is described on the [Flash M8P V2 and EBB SB2209](./flash-m8p-v2-ebb.mdx) page.
+</Callout>
 
 ## Preparing
 

--- a/pages/Firmware-Flash/flash-m8p-v2-ebb.mdx
+++ b/pages/Firmware-Flash/flash-m8p-v2-ebb.mdx
@@ -1,6 +1,10 @@
-# CBT Kit M8P V2 + CB1 Start Guide
+# CBT Kit Manta M8P V2 + CB1 Start Guide
 ## Introduction
 import { Callout } from 'nextra/components'
+
+<Callout type="info">
+MPX kits started shipping the V2 version of the Manta M8P in late 2023. If you have the older V1 version of the Manta, please refer to the [Flash M8P V1 and EBB SB2209](./flash-m8p-v1-ebb.mdx) page.
+</Callout>
 
 There are three microprocessors involved in running the printer: the one on the CB1, the one on the Manta M8P, and the one on the EBB SB2209 toolboard. Knowing how they all work together is important. The CB1 runs the show, the Manta gets delegated low level tasks like driving motors and fans from the CB1, and the EBB runs the Stealthburner in cooperation with the Manta.
 
@@ -128,7 +132,37 @@ iface can0 can static
     up ifconfig $IFACE txqueuelen 1024
 ```
 
-Save the file within the editor with Ctrl-O and then Enter to acknowledge. Reboot the CB1 from the command line:
+Save the file within the editor with Ctrl-O and then Enter to acknowledge. 
+
+### Disable Unnecessary Services
+
+By default, the BTT image for the CB1 runs several background services that are not properly configured by default and will repeatedly fail and restart every few seconds.  One service called `hostapd` tries to turn your printer into a wireless hotspot.  The other service called `klipper-mcu` allows use of the CB1 processor's GPIO and SPI ports as if it was a second MCU on top of the one already built into the Manta. Neither of these services is required for our purposes, and disabling them will ease the workload on the CB1 and minimize spam in your error logs.
+
+Assuming you are still connected to your printer via `ssh` from the previous step, enter these two commands to disable the two services.
+``` shell
+$ sudo systemctl disable hostapd
+$ sudo systemctl disable klipper-mcu
+```
+
+Your command and the resulting output should look like this:
+
+``` shell
+biqu@BTT-CB1:~$ sudo systemctl disable hostapd
+Synchronizing state of hostapd.service with SysV service script with /lib/systemd/systemd-sysv-install.
+Executing: /lib/systemd/systemd-sysv-install disable hostapd
+Removed /etc/systemd/system/multi-user.target.wants/hostapd.service.
+biqu@BTT-CB1:~$ sudo systemctl disable klipper-mcu
+Removed /etc/systemd/system/multi-user.target.wants/klipper-mcu.service.
+```
+
+<Callout type="info">
+If you have no use for KlipperScreen (the software that supports the printer's touchscreen GUI), you can disable it now or in the future with:
+```shell
+$ sudo systemctl disable KlipperScreen
+```
+</Callout>
+
+Reboot the CB1 from the command line for these changes and those in the previous section to take effect:
 ```
 $ reboot
 ```


### PR DESCRIPTION
- The default BTT image results in hostapd and klipper-mcu services failing every few seconds.  Disable them since they aren't used and fill the logs with spam.
- Make it clear that Manta V2 is the current Manta version, and users should only follow the V1 procedure if they are certain they have that version
- Put the V2 flashing version above V1 in the wiki Table of Contents