### PR TITLE
Restore 2nd thermistor pic + misc fixes

### DIFF
--- a/pages/Firmware-Setting/sensorless-homing-m8p-v2.mdx
+++ b/pages/Firmware-Setting/sensorless-homing-m8p-v2.mdx
@@ -10,7 +10,7 @@ Getting a basic understanding of how sensorless homing works now will be useful 
 - The signal from the stepper drivers gets to the Manta CPU via connection of something called the DIAG jumpers. This means three things in practice:
     - **First**: The physical endstops *must* not be installed / connnected or they will interfere with the operation of sensorless homing.  **The DIAG jumper connection takes the place of the physical endstop connection**.
     - **Second**: The EBB SB2209 is no longer involved with homing at all. We will not install the X-endstop to the toolhead and we will completely remove the reference to this endstop in our `printer.cfg`
-    - **Third**: The wiring from the MPX Y-endstop / chamber thermistor will need to be re-pinned so we can retain the chamber temperature function.
+    - **Third**: The wiring from the MPX Y-endstop / chamber thermistor will need to be modified so we can retain the chamber temperature function.
 
 ## DIAG Jumper Installation
 
@@ -29,15 +29,19 @@ The X-endstop on the Stealthburner can be removed / not installed. It *probably*
 
 ### Y Endstop
 
-What MPX calls the Y Endstop PCB *also* includes a very small thermistor that is used for measuring the chamber temperature. We want to retain this capability so we still want to install that PCB and we still need to run the wiring to it.  However,a bit of cable re-pinning will be required to get everything to work. Refer to the picture below. The green lines illustrate the original MPX wiring. The blue lines indicate where we want to end up after re-pinning.
+What MPX calls the Y Endstop PCB *also* includes a very small thermistor that is used for measuring the chamber temperature. We want to retain this capability so we still want to install that PCB and we still need to run the wiring to it **but** we need to change the wiring around a bit from the default: we want to retain a ground connection to the PCB but have the endstop switch ignored. There are two equally-effective methods for this, and the choice is up to you.
+
+#### Method 1: Cable Re-pinning
+
+This method re-pins the the chamber thermistor JST connector for the ground connection needed by the Y Endstop PCB.  Refer to the picture below. The green lines illustrate the original MPX wiring. The blue lines indicate where we want to end up after re-pinning.
 
 ![Connection Changes](https://img.mpx.wiki/i/2024/01/25/65b17599bfeca.webp)
 
 On both the three pin connectors, ground is the middle pin. The "Y Endstop PCB" has both a thermistor (across pins 2 & 3) and a switch (across pins 1 & 2). Re-pin the middle wire (“4”) from the "Y-Endstop" connector to “2” on the "Chamber Thermistor" connector. This relocates the Ground to the thermistor connection so that the M8P can read it. The wiring should now match the blue lines. The "Chamber Thermistor" will plug in to its original spot on the Manta. The "Y Endstop" connector can be left disconnected and tucked away in the PVC wiring channel in case you want to revert back to physical endstops later.
 
-<Callout type="info">
-It might also work to leave the pinouts as-is and just plug the 3-pin "Y Endstop" connector into another unused endstop connector on the Manta board. That would be another way to provide a Ground to the Y Endstop PCB, but this is untested.
-</Callout>
+#### Method 2: Unused Endstop Connection
+
+Method 2 is simple: leave the connector pinouts as-is and plug the 3-pin "Y Endstop" connector into another unused endstop connector on the Manta board. That retains the ground connection to the Y Endstop PCB without otherwise interrupting motor operation.
 
 ## Initial Software Configuration
 ### Changes to printer.cfg

--- a/pages/GENERAL-KIT/Assembly-Tips.mdx
+++ b/pages/GENERAL-KIT/Assembly-Tips.mdx
@@ -28,7 +28,7 @@ The plenum assembly album is very informative but it **does not** show some of t
 
 ## PEI / Buildplate / Heater
 
-The bed heater is pre-installed on the build plate, but you need to install the magnetic sheet yourself. The PEI and magnetic plate included in our kits are slightly larger than the buildplate size on purpose, so that you don't have to align them precisely when placing the spring steel. After sticking them on, you can use a blade to trim off the excess part.
+The bed heater is pre-installed on the build plate but you need to install the magnetic sheet yourself. The PEI and magnetic plate included in our kits are slightly larger than the buildplate size on purpose, so that you don't have to align them precisely when placing the spring steel. After sticking them on, you can use a blade to trim off the excess part.
 
 This [Nero3D video on YouTube](https://www.youtube.com/watch?v=X2S7mkyyC4E) shows how the magnetic plate can be applied. However, it is even easier if you take this advice in one of the comments:
 
@@ -37,6 +37,14 @@ This [Nero3D video on YouTube](https://www.youtube.com/watch?v=X2S7mkyyC4E) show
 <Callout type="info">
 You will need to cut holes in the magnetic sheet either before or after its application so you can fasten it to the bed frame later.
 </Callout>
+
+The MPX build plate includes a second thermistor for monitoring its temperature within Mainsail, and the MPX default `printer.cfg` files are preconfigured to read it. The thermistor attaches at the location shown below towards the back of the build plate. You can use a small amount of heatsink grease or thermal paste on its threads to improve its response time, but do note that its reading will still lag that of the standard heater thermistor by 5-10°C during warmup. **Be careful not to over-tighten the thermistor** or you will strip its threads.
+
+The two thermistors are cabled as follows:
+- the MPX cable labeled HE (HEater) connects to the pre-installed thermistor
+- the MPX cable labeled BP (Build Plate) connects to the second thermistor you install yourself
+
+![image-65ef2f05d89b5](https://img.mpx.wiki/i/2024/03/12/65ef2f05d89b5.webp)
 
 ## Stealthburner
 ### Main Body

--- a/pages/GENERAL-KIT/What-Else.mdx
+++ b/pages/GENERAL-KIT/What-Else.mdx
@@ -14,8 +14,10 @@
 12. Set of metric caliplers or a good metric ruler (Machinist's scale)
 13. Soldering iron for heat insert tool provided with the kit (T-12 type) and Nevermore fan wiring.
 
-## Recommended additional tools:
+## Recommended additional tools and supplies:
 1. Multimeter
 2. Tweezers for belt routing
 3. Machinist / Engineer's Square for squaring the frame
 4. Luer Lock Syringes for rail greasing.
+5. JST & Molex connector crimp tool for reterminating cables if necessary (e.g. IWISS IWS-2820M or Engineer PA-09)
+6. Heatsink compound or thermal paste for the installation of the second buildplate thermistor

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -8,7 +8,7 @@ Need more help? Just jump on Discord and ask! There is the [MPX Channel on the V
 
 ## Want to Help?
 
-Your are welcome to help improve this wiki!  You can fork [the github repo](https://github.com/MagicPhoenix/mpx-wiki/) and submit a PR.  All pages are in markdown format that is easy to learn. Images should be uploaded [to this site](https://github.com/MagicPhoenix/mpx-wiki/) (no login needed). Uploading an image will return a URL that you can then reference within the text.
+Your are welcome to help improve this wiki!  You can fork [the github repo](https://github.com/MagicPhoenix/mpx-wiki/) and submit a PR.  All pages are in markdown format that is easy to learn. Images should be uploaded [to this site](https://img.mpx.wiki/) (no login needed). Uploading an image will return a URL that you can then reference within the text.
 
 We appreciate your help in making the wiki better! 
 


### PR DESCRIPTION
This PR included the following
- shows install location for 2nd buildplate thermistor that used to be on the old wiki. This question comes up a lot.
- fixed a link I previously broke to img.mpx.wiki
- adds a few things to the recommended tools section (crimper and heat sink compound)
- updates sensorless homing section for alternative to repinning y endstop connector