### PR TITLE
Update Manta V2 flashing details + more troubleshooting

### DIFF
--- a/pages/Firmware-Flash/flash-m8p-v2-ebb.mdx
+++ b/pages/Firmware-Flash/flash-m8p-v2-ebb.mdx
@@ -174,6 +174,11 @@ $ reboot
 
 ## Flash M8P 
 
+<Callout type="info">
+If you run into a problem flashing the M8P in this section or the EBB in the next sections, check out the [Troubleshooting section](#troubleshooting) at the bottom of this page for ideas.
+</Callout>
+
+
 ```shell
 $ cd ~/klipper
 $ make menuconfig
@@ -185,7 +190,7 @@ Then set everything up as shown. Use the arrow keys to navigate and Enter to cha
 [*] Enable extra low-level configuration options
     Micro-controller Architecture (STMicroelectronics STM32)  --->
     Processor model (STM32H723)  --->
-    Bootloader offset (128KiB bootloader (SKR SE BX v2.0))  --->
+    Bootloader offset (128KiB bootloader)  --->
     Clock Reference (25 MHz crystal)  --->
     Communication interface (USB to CAN bus bridge (USB on PA11/PA12))  --->
     CAN bus interface (CAN bus (on PD0/PD1))  --->
@@ -194,7 +199,7 @@ Then set everything up as shown. Use the arrow keys to navigate and Enter to cha
 ()  GPIO pins to set at micro-controller startup (NEW)
 ```
 
-![image-20231012021820745](https://img.mpx.wiki/i/2023/10/12/6526e6ee74e55.webp)
+![KlipperMantaConfig2.webp](https://img.mpx.wiki/i/2024/04/15/661c5bae827cb.webp)
 
 Press Q to save and then run `make` from the terminal.
 
@@ -234,7 +239,7 @@ Your command and the resulting output should look like this:
 ```shell
 biqu@BTT-CB1:~/klipper$ make flash FLASH_DEVICE=0483:df11
   Flashing out/klipper.bin to 0483:df11
-sudo dfu-util -d ,0483:df11 -R -a 0 -s 0x8002000:leave -D out/klipper.bin
+sudo dfu-util -d ,0483:df11 -R -a 0 -s 0x8020000:leave -D out/klipper.bin
 
 dfu-util 0.9
 
@@ -255,8 +260,8 @@ dfuIDLE, continuing
 DFU mode device DFU version 011a
 Device returned transfer size 1024
 DfuSe interface name: "Internal Flash   "
-Downloading to address = 0x08002000, size = 28732
-Download	[=========================] 100%        28732 bytes
+Downloading to address = 0x08020000, size = 31336
+Download	[=========================] 100%        31336 bytes
 Download done.
 File downloaded successfully
 dfu-util: Error during download get_status
@@ -501,6 +506,9 @@ Finally, remove the `v_usb` jumper on the M8P and `usb_5v` jumper on the EBB SB.
 
 **Problem**: I flashed the Manta board and I see an entry for it with `lsusb` after doing so, but it disappears from `lsusb` after I reboot or cycle power.
 - The Manta bootloader has probably been corrupted, possibly by flashing the EBB Canboot image to the Manta instead of the EBB by mistake. Follow [these instructions on the BTT Github](https://github.com/bigtreetech/Manta-M8P/tree/master/V2.0/Firmware) to restore the bootloader on the Manta.
+
+**Problem**: I am trying to flash the Manta / EBB but the system is not stable. The Canbus connection disconnects and reconnects, interfaces disappear and reappear, etc.
+- You might have a weak USB power supply. We have seen instances where a marginal supply will cause the Manta to drop in and out while the CB1 operates normally. Or the CB1 and Manta might operate OK but the setup becomes unstable when the SB2209 is connected. Switch to a power supply / USB port that can provide more current and see if the problem goes away.
 
 **Problem**: I am using a Raspberry Pi CM4 instead of the BigTreeTech CB1 and ```username: biqu```, ```password: biqu``` does not work for me.
 - See the BTT manual. For this board it should be ```username: pi```, ```password: raspberry```


### PR DESCRIPTION
- Fix for a copy and paste error between Manta V1 and V2.
- Updated `make menuconfig` screen for latest Klipper on Manta
- Added another troubleshooting step.

Reference: https://discord.com/channels/707214359582998650/887356023873089607/1229124980248285284