### PR TITLE
Fix broken links after BTT renamed the files

### DIFF
--- a/pages/GENERAL-KIT/Wiring-Guide.mdx
+++ b/pages/GENERAL-KIT/Wiring-Guide.mdx
@@ -40,12 +40,11 @@ This image shows the SB2209 installed on the body of the Stealthburner. Note tha
 
 ### Optional Printed Part
 
-BIGTREETECH has a modified CW2 main_body and cable_door printed parts. They can improve the fit of the SB2209 within the Stealthburner.
+BIGTREETECH has modified printed parts for the CW2 main body and cable cover. They can improve the fit of the SB2209 within the Stealthburner.
 
 - [BIGTREETECH SB2209 Github STLs](https://github.com/bigtreetech/EBB/tree/master/EBB%20SB2240_2209%20CAN/STL)
-- [Cable Cover for PCB V1.2](https://github.com/bigtreetech/EBB/blob/master/EBB%20SB2240_2209%20CAN/STL/Cable_Cover_For_PCB_V1.2.stl)
-- [Main Body v1.2](https://github.com/bigtreetech/EBB/blob/master/EBB%20SB2240_2209%20CAN/STL/Main_Body_V1.2.stl)
-
+- [Main Body EBB](https://github.com/bigtreetech/EBB/blob/master/EBB%20SB2240_2209%20CAN/STL/Main_Body_EBB.stl)
+- [Cable Cover EBB](https://github.com/bigtreetech/EBB/blob/master/EBB%20SB2240_2209%20CAN/STL/Cable_Cover_EBB.stl)
 
 ## EBB SB0000 Expansion Board
 


### PR DESCRIPTION
Links for the BTT SB main body and cable cover STL's were renamed over the last couple of months.